### PR TITLE
Add readme tip to force string types

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,7 +55,8 @@ OPTIONS:
 
         --max-read-records <max-read-records>
             The number of records to infer the schema from. All rows if not present.
-            If max-read-records is set to zero, then the schema will infer all string types.
+            Setting max-read-records to zero, will stop schema inference.  All the columns
+            will be string typed.
 
         --max-row-group-size <max-row-group-size>                  Sets max size for a row group
         --max-statistics-size <max-statistics-size>

--- a/Readme.md
+++ b/Readme.md
@@ -55,7 +55,7 @@ OPTIONS:
 
         --max-read-records <max-read-records>
             The number of records to infer the schema from. All rows if not present.
-            Setting max-read-records to zero will stop schema inference.  All the columns
+            Setting max-read-records to zero will stop schema inference.  All columns
             will be string typed.
 
         --max-row-group-size <max-row-group-size>                  Sets max size for a row group

--- a/Readme.md
+++ b/Readme.md
@@ -55,7 +55,7 @@ OPTIONS:
 
         --max-read-records <max-read-records>
             The number of records to infer the schema from. All rows if not present.
-            Setting max-read-records to zero, will stop schema inference.  All the columns
+            Setting max-read-records to zero will stop schema inference.  All the columns
             will be string typed.
 
         --max-row-group-size <max-row-group-size>                  Sets max size for a row group

--- a/Readme.md
+++ b/Readme.md
@@ -54,7 +54,8 @@ OPTIONS:
             Set whether the CSV file has headers
 
         --max-read-records <max-read-records>
-            The number of records to infer the schema from. All rows if not present
+            The number of records to infer the schema from. All rows if not present.
+            If max-read-records is set to zero, then the schema will infer all string types.
 
         --max-row-group-size <max-row-group-size>                  Sets max size for a row group
         --max-statistics-size <max-statistics-size>


### PR DESCRIPTION
Very useful utility, thanks for creating this repo.
I find it useful to not have the Arrow infer types.   I want all string columns.
This can be easily done by setting max-read-records == 0.