### PR TITLE
Moving comment to clip macro

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,7 +55,8 @@ OPTIONS:
 
         --max-read-records <max-read-records>
             The number of records to infer the schema from. All rows if not present.
-            If max-read-records is set to zero, then the schema will infer all string types.
+            Setting max-read-records to zero, will stop schema inference.  All the columns
+            will be string typed.
 
         --max-row-group-size <max-row-group-size>                  Sets max size for a row group
         --max-statistics-size <max-statistics-size>

--- a/Readme.md
+++ b/Readme.md
@@ -55,7 +55,7 @@ OPTIONS:
 
         --max-read-records <max-read-records>
             The number of records to infer the schema from. All rows if not present.
-            Setting max-read-records to zero will stop schema inference.  All the columns
+            Setting max-read-records to zero will stop schema inference.  All columns
             will be string typed.
 
         --max-row-group-size <max-row-group-size>                  Sets max size for a row group

--- a/Readme.md
+++ b/Readme.md
@@ -55,7 +55,7 @@ OPTIONS:
 
         --max-read-records <max-read-records>
             The number of records to infer the schema from. All rows if not present.
-            Setting max-read-records to zero, will stop schema inference.  All the columns
+            Setting max-read-records to zero will stop schema inference.  All the columns
             will be string typed.
 
         --max-row-group-size <max-row-group-size>                  Sets max size for a row group

--- a/Readme.md
+++ b/Readme.md
@@ -54,7 +54,8 @@ OPTIONS:
             Set whether the CSV file has headers
 
         --max-read-records <max-read-records>
-            The number of records to infer the schema from. All rows if not present
+            The number of records to infer the schema from. All rows if not present.
+            If max-read-records is set to zero, then the schema will infer all string types.
 
         --max-row-group-size <max-row-group-size>                  Sets max size for a row group
         --max-statistics-size <max-statistics-size>

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,8 @@ struct Opts {
     output: PathBuf,
 
     /// The number of records to infer the schema from. All rows if not present.
+    /// Setting max-read-records to zero will stop schema inference.
+    /// All columns will be string typed.
     #[clap(long)]
     max_read_records: Option<usize>,
 


### PR DESCRIPTION
Moving the about text to the clip macro because README.md is generated.