### PR TITLE
feat: support schema file as command line arg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.py
 *.txt
 *.tsv
+
+.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.5"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced1892c55c910c1219e98d6fc8d71f6bddba7905866ce740066d8bfea859312"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
 dependencies = [
  "atty",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.9"
+version = "3.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aad2534fad53df1cc12519c5cda696dd3e20e6118a027e24054aea14a0bdcbe"
+checksum = "7c167e37342afc5f33fd87bbc870cedd020d2a6dffa05d45ccd9241fbdd146db"
 dependencies = [
  "atty",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "9.1.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9864ca2fdcd3d4883259495b4517879877c5991d9928cc9713794d8076d3e78b"
+checksum = "e94e2d315bc11f3d43f38344141453282591788381061fabc06c95e37d0dbc7d"
 dependencies = [
  "bitflags",
  "chrono",
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4c5738bcd7fad10315029c50026f83c9da5e4a21f8ed66826f43e0e2bde5f6"
+checksum = "6ea97b4fe4b84e2f2765449bcea21cbdb3ee28cecb88afbf38a0c2e1639f5eb5"
 dependencies = [
  "bitflags",
  "smallvec",
@@ -579,9 +579,9 @@ checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "parquet"
-version = "9.1.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1697d963e6319c19099adcf131a5440685053d4902890f9e4bb272cbd0dc6532"
+checksum = "13c5df78854c7d56aed3aba69fb1b342dda41c384963f4ddfa962b690572b42a"
 dependencies = [
  "arrow",
  "base64",
@@ -887,18 +887,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zstd"
-version = "0.10.0+zstd.1.5.2"
+version = "0.11.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1365becbe415f3f0fcd024e2f7b45bacfb5bdd055f0dc113571394114e7bdd"
+checksum = "77a16b8414fde0414e90c612eba70985577451c4c504b99885ebed24762cb81a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.4+zstd.1.5.2"
+version = "5.0.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7cd17c9af1a4d6c24beb1cc54b17e2ef7b593dc92f19e9d9acad8b182bbaee"
+checksum = "7c12659121420dd6365c5c3de4901f97145b79651fb1d25814020ed2ed0585ae"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -906,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.3+zstd.1.5.2"
+version = "2.0.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,16 +153,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.8"
+version = "3.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+checksum = "6aad2534fad53df1cc12519c5cda696dd3e20e6118a027e24054aea14a0bdcbe"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
  "lazy_static",
- "os_str_bytes",
  "strsim",
  "termcolor",
  "textwrap",
@@ -179,6 +179,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -567,9 +576,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "parquet"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.6"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
  "atty",
  "bitflags",
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.4"
+version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.2"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
+checksum = "ced1892c55c910c1219e98d6fc8d71f6bddba7905866ce740066d8bfea859312"
 dependencies = [
  "atty",
  "bitflags",
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.2"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d42c94ce7c2252681b5fed4d3627cc807b13dfc033246bd05d5b252399000e"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -784,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ description = "Convert CSV files to Parquet"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-parquet = "9.1.0"
-arrow = "9.1.0"
+#parquet = "9.1.0"
+#arrow = "9.1.0"
+parquet = "12.0.0"
+arrow = "12.0.0"
 serde_json = "1.0.79"
 clap = { version = "3.1.12", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ description = "Convert CSV files to Parquet"
 parquet = "9.1.0"
 arrow = "9.1.0"
 serde_json = "1.0.79"
-clap = { version = "3.1.6", features = ["derive"] }
+clap = { version = "3.1.8", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ description = "Convert CSV files to Parquet"
 parquet = "9.1.0"
 arrow = "9.1.0"
 serde_json = "1.0.79"
-clap = { version = "3.1.9", features = ["derive"] }
+clap = { version = "3.1.12", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ description = "Convert CSV files to Parquet"
 parquet = "9.1.0"
 arrow = "9.1.0"
 serde_json = "1.0.79"
-clap = { version = "3.1.5", features = ["derive"] }
+clap = { version = "3.1.6", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ description = "Convert CSV files to Parquet"
 parquet = "9.1.0"
 arrow = "9.1.0"
 serde_json = "1.0.79"
-clap = { version = "3.1.2", features = ["derive"] }
+clap = { version = "3.1.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ description = "Convert CSV files to Parquet"
 parquet = "9.1.0"
 arrow = "9.1.0"
 serde_json = "1.0.79"
-clap = { version = "3.1.8", features = ["derive"] }
+clap = { version = "3.1.9", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,6 @@ fn main() -> Result<(), ParquetError> {
         }
     }
 
-    //let reader = builder.build(input)?;
     let schema_ref = Arc::new(schema);
     let builder = ReaderBuilder::new()
         .has_header(opts.header.unwrap_or(true))

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ fn main() -> Result<(), ParquetError> {
 
     let mut input = File::open(opts.input)?;
 
-    let schema = match opts.schema_def_file {
+    let schema = match opts.schema_file {
         Some(schema_def_file_path) => {
             let schema_file = match File::open(&schema_def_file_path) {
                 Ok(file) => Ok(file),
@@ -126,7 +126,7 @@ fn main() -> Result<(), ParquetError> {
                 ))),
             }?;
             let json: serde_json::Result<Value> = serde_json::from_reader(schema_file);
-            match json_read_result {
+            match json {
                 Ok(schema_json) => match arrow::datatypes::Schema::from(&schema_json) {
                     Ok(schema) => Ok(schema),
                     Err(error) => Err(error.into()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,10 +46,9 @@ struct Opts {
     #[clap(name = "PARQUET", parse(from_os_str), value_hint = ValueHint::AnyPath)]
     output: PathBuf,
 
-    /// Arrow schema to be applied to data in CSV (same format as written out by -p / -n), prevents schema inference from running.
-    /// The structure of schema json is shown in the source of: DataType fn from(json: &Value -> Result<DataType> in:
-    /// https://github.com/apache/arrow-rs/blob/master/arrow/src/datatypes/datatype.rs
-    /// Make sure your schema has the same number of columns as your CSV!
+    /// Specify a file that contains an Arrow schema to be applied to source data. The schema should be in the same format as written by -p / -n.
+    /// When a schema file is defined, no attempt will be made to infer a schema.
+    /// The structure of schema JSON is shown in the source of: DataType fn from(json: &Value -> Result<DataType> in: https://github.com/apache/arrow-rs/blob/master/arrow/src/datatypes/datatype.rs
     #[clap(short = 's', long, parse(from_os_str), value_hint = ValueHint::AnyPath)]
     schema_def_file: Option<PathBuf>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,9 +148,9 @@ fn main() -> Result<(), ParquetError> {
                 opts.header.unwrap_or(true),
             ) {
                 Ok((schema, _inferred_has_header)) => Ok(schema),
-                Err(infer_schema_err) => Err(ParquetError::General(format!(
+                Err(error) => Err(ParquetError::General(format!(
                     "Error inferring schema: {}",
-                    infer_schema_err
+                    error
                 ))),
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ struct Opts {
     /// When a schema file is defined, no attempt will be made to infer a schema.
     /// The structure of schema JSON is shown in the source of: DataType fn from(json: &Value -> Result<DataType> in: https://github.com/apache/arrow-rs/blob/master/arrow/src/datatypes/datatype.rs
     #[clap(short = 's', long, parse(from_os_str), value_hint = ValueHint::AnyPath)]
-    schema_def_file: Option<PathBuf>,
+    schema_file: Option<PathBuf>,
 
     /// The number of records to infer the schema from. All rows if not present. Setting max-read-records to zero will stop schema inference and all columns will be string typed.
     #[clap(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,7 @@ fn main() -> Result<(), ParquetError> {
                     schema_def_file_path, error
                 ))),
             }?;
-            let json_read_result: serde_json::Result<Value> = serde_json::from_reader(schema_file);
+            let json: serde_json::Result<Value> = serde_json::from_reader(schema_file);
             match json_read_result {
                 Ok(schema_json) => match arrow::datatypes::Schema::from(&schema_json) {
                     Ok(schema) => Ok(schema),

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,9 +123,9 @@ fn main() -> Result<(), ParquetError> {
         Some(schema_def_file_path) => {
             let schema_file = match File::open(&schema_def_file_path) {
                 Ok(file) => Ok(file),
-                Err(open_schema_file_err) => Err(ParquetError::General(format!(
+                Err(error) => Err(ParquetError::General(format!(
                     "Error opening schema file: {:?}, message: {}",
-                    schema_def_file_path, open_schema_file_err
+                    schema_def_file_path, error
                 ))),
             }?;
             let json_read_result: serde_json::Result<Value> = serde_json::from_reader(schema_file);

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,9 +46,7 @@ struct Opts {
     #[clap(name = "PARQUET", parse(from_os_str), value_hint = ValueHint::AnyPath)]
     output: PathBuf,
 
-    /// Specify a file that contains an Arrow schema to be applied to source data. The schema should be in the same format as written by -p / -n.
-    /// When a schema file is defined, no attempt will be made to infer a schema.
-    /// The structure of schema JSON is shown in the source of: DataType fn from(json: &Value -> Result<DataType> in: https://github.com/apache/arrow-rs/blob/master/arrow/src/datatypes/datatype.rs
+    /// File with Arrow schema in JSON format.
     #[clap(short = 's', long, parse(from_os_str), value_hint = ValueHint::AnyPath)]
     schema_file: Option<PathBuf>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,7 @@ fn main() -> Result<(), ParquetError> {
             match json_read_result {
                 Ok(schema_json) => match arrow::datatypes::Schema::from(&schema_json) {
                     Ok(schema) => Ok(schema),
-                    Err(schema_err) => Err(ParquetError::ArrowError(schema_err.to_string())),
+                    Err(error) => Err(error.into()),
                 },
                 Err(err) => Err(ParquetError::General(format!(
                     "Error reading schema json: {}",


### PR DESCRIPTION
As discussed in issue #73, here is a first cut at enabling a schema file to be supplied as a command line arg.

It relies entirely upon the json schema handling provided by arrow, which means there can be unexpected outcomes if mistakes are made while defining the schema...

The main problem will be that it seems the columns in the json schema are applied in numeric order to the columns in the CSV. If the json schema omits a column, the column definitions will get misaligned, meaning that columns may end up with the wrong heading or there are (poorly reported) incompatibilities between the data in the CSV file and the type expected for the column (i.e. trying to push a float into an int).

These problems can largely be avoided by using the schema inference process to generate an initial schema file, which can be edited prior to running a full convert.

As there is a pretty straight forward way of getting most cases to work with the functionality as implemented here, this seems like a good place to start. (it's good enough for my needs at the moment anyway :) )

Note: I wrote this against Arrow/Parquet 9.1.0 and got it working, then raised the version of those dependencies to 12.0.0 (latest release) and everything continued to just compile and work.
