### PR TITLE
fix: Build csv2arrow, csv2parquet, json2arrow and json2parquet from just one codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,16 +238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv2parquet"
-version = "0.4.0"
-dependencies = [
- "arrow",
- "clap",
- "parquet",
- "serde_json",
-]
-
-[[package]]
 name = "flatbuffers"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +853,16 @@ dependencies = [
  "log",
  "ordered-float",
  "threadpool",
+]
+
+[[package]]
+name = "to-parquet"
+version = "0.4.0"
+dependencies = [
+ "arrow",
+ "clap",
+ "parquet",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "csv2parquet"
+name = "to-parquet"
 version = "0.4.0"
 authors = ["Dominik Moritz <domoritz@cmu.edu>"]
 license = "MIT/Apache-2.0"
 edition = "2018"
 repository = "https://github.com/domoritz/csv2parquet"
-description = "Convert CSV files to Parquet"
+description = "Convert CSV or JSON files to Parquet"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/bin/csv2arrow.rs
+++ b/src/bin/csv2arrow.rs
@@ -1,0 +1,6 @@
+use arrow::error::ArrowError;
+use to_parquet::{ArrowOpts, CsvOpts};
+
+fn main() -> Result<(), ArrowError> {
+    to_parquet::run::<CsvOpts, ArrowOpts>()
+}

--- a/src/bin/csv2parquet.rs
+++ b/src/bin/csv2parquet.rs
@@ -1,0 +1,6 @@
+use to_parquet::CsvOpts;
+use parquet::errors::ParquetError;
+
+fn main() -> Result<(), ParquetError> {
+    to_parquet::run::<CsvOpts>()
+}

--- a/src/bin/csv2parquet.rs
+++ b/src/bin/csv2parquet.rs
@@ -1,6 +1,6 @@
-use parquet::errors::ParquetError;
-use to_parquet::CsvOpts;
+use arrow::error::ArrowError;
+use to_parquet::{CsvOpts, ParquetOpts};
 
-fn main() -> Result<(), ParquetError> {
-    to_parquet::run::<CsvOpts>()
+fn main() -> Result<(), ArrowError> {
+    to_parquet::run::<CsvOpts, ParquetOpts>()
 }

--- a/src/bin/csv2parquet.rs
+++ b/src/bin/csv2parquet.rs
@@ -1,5 +1,5 @@
-use to_parquet::CsvOpts;
 use parquet::errors::ParquetError;
+use to_parquet::CsvOpts;
 
 fn main() -> Result<(), ParquetError> {
     to_parquet::run::<CsvOpts>()

--- a/src/bin/json2arrow.rs
+++ b/src/bin/json2arrow.rs
@@ -1,0 +1,6 @@
+use arrow::error::ArrowError;
+use to_parquet::{ArrowOpts, JsonOpts};
+
+fn main() -> Result<(), ArrowError> {
+    to_parquet::run::<JsonOpts, ArrowOpts>()
+}

--- a/src/bin/json2parquet.rs
+++ b/src/bin/json2parquet.rs
@@ -1,6 +1,6 @@
-use parquet::errors::ParquetError;
-use to_parquet::JsonOpts;
+use arrow::error::ArrowError;
+use to_parquet::{JsonOpts, ParquetOpts};
 
-fn main() -> Result<(), ParquetError> {
-    to_parquet::run::<JsonOpts>()
+fn main() -> Result<(), ArrowError> {
+    to_parquet::run::<JsonOpts, ParquetOpts>()
 }

--- a/src/bin/json2parquet.rs
+++ b/src/bin/json2parquet.rs
@@ -1,0 +1,6 @@
+use to_parquet::JsonOpts;
+use parquet::errors::ParquetError;
+
+fn main() -> Result<(), ParquetError> {
+    to_parquet::run::<JsonOpts>()
+}

--- a/src/bin/json2parquet.rs
+++ b/src/bin/json2parquet.rs
@@ -1,5 +1,5 @@
-use to_parquet::JsonOpts;
 use parquet::errors::ParquetError;
+use to_parquet::JsonOpts;
 
 fn main() -> Result<(), ParquetError> {
     to_parquet::run::<JsonOpts>()


### PR DESCRIPTION
This tool and its companion [json2parquet](https://github.com/domoritz/json2parquet) really fill an important niche, thank you so much for figuring this out!  I'd been wanting to try and write this, but been daunted by Rust.

I did however look at the repos, noted all the code duplication, and that didn't sit right with me, so I sat down and stared at unfamiliar Rust error messages for a couple of hours to see if I could figure out a way of making the meat of the code more generic and thus build both executables from the same codebase.  And somehow I did manage to get something working!  There's likely a better way of doing this, but hopefully this at lest serves as a working example.