### PR TITLE
docs: added examples

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,3 +88,46 @@ OPTIONS:
 ```
 
 The --schema-file option uses the same file format as --dry and --print-schema.
+
+## Examples
+### Convert a CSV to PARQUET
+```bash
+csv2parquet data.csv data.parquet
+```
+
+### Convert a CSV with no `header` to PARQUET
+```bash
+csv2parquet --header false <CSV> <PARQUET>
+```
+
+### Get the `schema` from a CSV with header
+```bash
+csv2parquet --header true --dry <CSV> <PARQUET>
+```
+
+### Convert a CSV using `schema-file` to PARQUET
+- Below is an example of the `schema-file` content:
+```json
+{
+  "fields": [
+    {
+      "name": "col1",
+      "data_type": "Utf8",
+      "nullable": false,
+      "dict_id": 0,
+      "dict_is_ordered": false
+    },
+    {
+      "name": " col2",
+      "data_type": "Utf8",
+      "nullable": false,
+      "dict_id": 0,
+      "dict_is_ordered": false
+    }
+  ]
+}
+```
+- Then add the schema-file `schema.json` in the command:
+```
+csv2parquet --header false --schema-file schema.json <CSV> <PARQUET>
+```

--- a/Readme.md
+++ b/Readme.md
@@ -90,6 +90,7 @@ OPTIONS:
 The --schema-file option uses the same file format as --dry and --print-schema.
 
 ## Examples
+
 ### Convert a CSV to Parquet
 ```bash
 csv2parquet data.csv data.parquet

--- a/Readme.md
+++ b/Readme.md
@@ -127,7 +127,8 @@ csv2parquet --header true --dry <CSV> <PARQUET>
   ]
 }
 ```
-- Then add the schema-file `schema.json` in the command:
+
+Then add the schema-file `schema.json` in the command:
 ```
 csv2parquet --header false --schema-file schema.json <CSV> <PARQUET>
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -106,7 +106,9 @@ csv2parquet --header true --dry <CSV> <PARQUET>
 ```
 
 ### Convert a CSV using `schema-file` to PARQUET
-- Below is an example of the `schema-file` content:
+
+Below is an example of the `schema-file` content:
+
 ```json
 {
   "fields": [

--- a/Readme.md
+++ b/Readme.md
@@ -90,7 +90,7 @@ OPTIONS:
 The --schema-file option uses the same file format as --dry and --print-schema.
 
 ## Examples
-### Convert a CSV to PARQUET
+### Convert a CSV to Parquet
 ```bash
 csv2parquet data.csv data.parquet
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -96,7 +96,7 @@ The --schema-file option uses the same file format as --dry and --print-schema.
 csv2parquet data.csv data.parquet
 ```
 
-### Convert a CSV with no `header` to PARQUET
+### Convert a CSV with no `header` to Parquet
 ```bash
 csv2parquet --header false <CSV> <PARQUET>
 ```
@@ -106,7 +106,7 @@ csv2parquet --header false <CSV> <PARQUET>
 csv2parquet --header true --dry <CSV> <PARQUET>
 ```
 
-### Convert a CSV using `schema-file` to PARQUET
+### Convert a CSV using `schema-file` to Parquet
 
 Below is an example of the `schema-file` content:
 


### PR DESCRIPTION
fixes https://github.com/domoritz/csv2parquet/issues/84

Added the below example:
- Convert a CSV to PARQUET
- Convert a CSV with no `header` to PARQUET
- Get the `schema` from a CSV with header
- Convert a CSV using `schema-file` to PARQUET