### PR TITLE
docs: add metadata field to the json schema example in the readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -96,16 +96,19 @@ Below is an example of the `schema-file` content:
       "data_type": "Utf8",
       "nullable": false,
       "dict_id": 0,
-      "dict_is_ordered": false
+      "dict_is_ordered": false,
+      "metadata": {}
     },
     {
       "name": " col2",
       "data_type": "Utf8",
       "nullable": false,
       "dict_id": 0,
-      "dict_is_ordered": false
+      "dict_is_ordered": false,
+      "metadata": {}
     }
-  ]
+  ],
+  " metadata": {}
 }
 ```
 


### PR DESCRIPTION
Add metadata field to the json schema example in the Readme.md file.
fixes #128